### PR TITLE
Add MP3_HIFI to AudioFormat Enum

### DIFF
--- a/pandora.py
+++ b/pandora.py
@@ -7,6 +7,7 @@ from bisect import bisect_left
 class AudioFormat(enum.Enum):
     """Supported formats to request"""
     MP3 = 'mp3'
+    MP3_HIFI = 'mp3-hifi'
     AACPLUS = 'aacplus'
 
 


### PR DESCRIPTION
Paid users have the option to get the 'mp3-hifi' audio format which equals 192kbit/s MP3 for Pandora Plus users.