### PR TITLE
Add output.mp3 and gbulb/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .mypy_cache/
 __pycache__/
 /docs/_build/
+output.mp3
+gbulb/


### PR DESCRIPTION
output.mp3 is a copywrited binary, so that's a no brainer.
As for gbulb it's nice to not have to install gbulb but instead just have the folder in the project folder.